### PR TITLE
adding nbgrader 

### DIFF
--- a/mamba.yml
+++ b/mamba.yml
@@ -49,6 +49,7 @@ dependencies:
 - mypy
 - nbdime
 - nbgitpuller
+- nbgrader
 - networkx
 - nltk
 - nodejs >=12,<13


### PR DESCRIPTION
[binder](https://gke.mybinder.org/v2/gh/deathbeds/_fam/nbgrader)

jupytercon encourages the use of nbgrader. adding it so we make quizzes work.

according to the installation conda installs all of the extensions https://github.com/jupyter/nbgrader/blob/fe90dee6687476047b0c281f9702ef9209089064/nbgrader/docs/source/user_guide/installation.rst#nbgrader-extensions